### PR TITLE
Revert library name change

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,4 +1,4 @@
-name=ClosedCube I2C Driver
+name=ClosedCube_I2C_Driver
 version=2020.9.8
 author=ClosedCube
 maintainer=ClosedCube GitHub Support <github@closedcube.com>


### PR DESCRIPTION
Libraries are locked to the `name` value specified by the library.properties metadata file in the release at the time of
the Library Manager submission.

Any release with a different name is rejected by the Arduino Library Manager indexer.

References:
- https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ#why-arent-releases-of-my-library-being-picked-up-by-library-manager
- https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ#how-can-i-change-my-librarys-name